### PR TITLE
Add vehicle details fields and update API schema

### DIFF
--- a/openAPI.yaml
+++ b/openAPI.yaml
@@ -391,6 +391,10 @@ paths:
       responses:
         "200":
           description: Vehicle found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/VehicleResponse"
         "404":
           description: Vehicle not found
     put:
@@ -408,10 +412,14 @@ paths:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/VehicleInput"
+              $ref: "#/components/schemas/VehicleUpdateInput"
       responses:
         "200":
           description: Vehicle updated successfully
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/VehicleResponse"
         "404":
           $ref: "#/components/responses/NotFound"
     patch:
@@ -429,10 +437,14 @@ paths:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/VehicleInput"
+              $ref: "#/components/schemas/VehicleUpdateInput"
       responses:
         "200":
           description: Vehicle partially updated successfully
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/VehicleResponse"
         "400":
           $ref: "#/components/responses/ValidationError"
         "404":
@@ -1710,6 +1722,31 @@ components:
           minimum: 1900
           maximum: 2030
           example: 2022
+        chassisNumber:
+          type: string
+          nullable: true
+          description: "Número de chasis"
+          example: "8ADZZZ12345678901"
+        engineNumber:
+          type: string
+          nullable: true
+          description: "Número de motor"
+          example: "1NZ-FE-987654321"
+        vehicleType:
+          type: string
+          nullable: true
+          description: "Tipo de vehículo (sedán, pickup, SUV, utilitario, etc.)"
+          example: "SUV"
+        transmission:
+          type: string
+          nullable: true
+          description: "Tipo de transmisión (manual, automática, CVT, etc.)"
+          example: "Automática"
+        fuelType:
+          type: string
+          nullable: true
+          description: "Tipo de combustible (nafta, diésel, híbrido, eléctrico, etc.)"
+          example: "Nafta"
         currentResponsible:
           allOf:
             - $ref: "#/components/schemas/VehicleResponsibleWithDetails"
@@ -1740,11 +1777,57 @@ components:
           type: integer
           minimum: 1900
           maximum: 2030
+        chassisNumber:
+          type: string
+          description: "Número de chasis"
+        engineNumber:
+          type: string
+          description: "Número de motor"
+        vehicleType:
+          type: string
+          description: "Tipo de vehículo"
+        transmission:
+          type: string
+          description: "Transmisión"
+        fuelType:
+          type: string
+          description: "Combustible"
       required:
         - licensePlate
         - brand
         - model
         - year
+
+    VehicleUpdateInput:
+      type: object
+      description: Campos de vehículo para actualización parcial o total. Todos los campos son opcionales.
+      properties:
+        licensePlate:
+          type: string
+          pattern: "^[A-Z]{3}[0-9]{3}$"
+        brand:
+          type: string
+          minLength: 1
+          maxLength: 50
+        model:
+          type: string
+          minLength: 1
+          maxLength: 50
+        year:
+          type: integer
+          minimum: 1900
+          maximum: 2030
+        chassisNumber:
+          type: string
+        engineNumber:
+          type: string
+        vehicleType:
+          type: string
+        transmission:
+          type: string
+        fuelType:
+          type: string
+      minProperties: 1
 
     # VEHICLE RESPONSIBLE SCHEMAS
     VehicleResponsible:

--- a/src/entities/Vehicle.ts
+++ b/src/entities/Vehicle.ts
@@ -16,4 +16,19 @@ export class Vehicle {
 
   @Column()
   year!: number;
+
+  @Column({ name: "chassis_number", nullable: true })
+  chassisNumber?: string;
+
+  @Column({ name: "engine_number", nullable: true })
+  engineNumber?: string;
+
+  @Column({ name: "vehicle_type", nullable: true })
+  vehicleType?: string;
+
+  @Column({ nullable: true })
+  transmission?: string;
+
+  @Column({ name: "fuel_type", nullable: true })
+  fuelType?: string;
 }

--- a/src/schemas/vehicle.ts
+++ b/src/schemas/vehicle.ts
@@ -8,6 +8,11 @@ export const VehicleSchema = z.object({
   brand: z.string(),
   model: z.string(),
   year: z.number(),
+  chassisNumber: z.string().optional(),
+  engineNumber: z.string().optional(),
+  vehicleType: z.string().optional(),
+  transmission: z.string().optional(),
+  fuelType: z.string().optional(),
 });
 
 export type Vehicle = z.infer<typeof VehicleSchema>;

--- a/src/services/vehicles/vehiclesService.ts
+++ b/src/services/vehicles/vehiclesService.ts
@@ -7,7 +7,7 @@ import { VehicleRepository } from "../../repositories/VehicleRepository";
 export class VehiclesService {
   constructor(
     private readonly vehicleRepo = new VehicleRepository(AppDataSource),
-    private readonly responsiblesService = new VehicleResponsiblesService(),
+    private readonly responsiblesService = new VehicleResponsiblesService()
   ) {}
 
   async getAll(options?: {
@@ -20,7 +20,7 @@ export class VehiclesService {
   }
 
   async getById(
-    id: string,
+    id: string
   ): Promise<(Vehicle & { currentResponsible?: unknown }) | null> {
     const entity = await this.vehicleRepo.findOne(id);
     if (!entity) return null;
@@ -38,6 +38,11 @@ export class VehiclesService {
       brand: vehicle.brand,
       model: vehicle.model,
       year: vehicle.year,
+      chassisNumber: vehicle.chassisNumber,
+      engineNumber: vehicle.engineNumber,
+      vehicleType: vehicle.vehicleType,
+      transmission: vehicle.transmission,
+      fuelType: vehicle.fuelType,
     });
     const saved = await this.vehicleRepo.save(created);
     return mapEntity(saved);
@@ -51,6 +56,11 @@ export class VehiclesService {
       brand: vehicle.brand ?? existing.brand,
       model: vehicle.model ?? existing.model,
       year: vehicle.year ?? existing.year,
+      chassisNumber: vehicle.chassisNumber ?? existing.chassisNumber,
+      engineNumber: vehicle.engineNumber ?? existing.engineNumber,
+      vehicleType: vehicle.vehicleType ?? existing.vehicleType,
+      transmission: vehicle.transmission ?? existing.transmission,
+      fuelType: vehicle.fuelType ?? existing.fuelType,
     });
     const saved = await this.vehicleRepo.save(existing);
     return mapEntity(saved);
@@ -70,6 +80,11 @@ function mapEntity(e: VehicleEntity): Vehicle {
     brand: e.brand,
     model: e.model,
     year: e.year,
+    chassisNumber: e.chassisNumber,
+    engineNumber: e.engineNumber,
+    vehicleType: e.vehicleType,
+    transmission: e.transmission,
+    fuelType: e.fuelType,
   };
 }
 


### PR DESCRIPTION
Introduced new optional fields to the Vehicle entity: chassisNumber, engineNumber, vehicleType, transmission, and fuelType. Updated the OpenAPI schema to reflect these changes, including new VehicleUpdateInput for partial updates and enhanced response schemas. Adjusted the Zod schema and service logic to handle the new fields for create, update, and retrieval operations.